### PR TITLE
Support many different APIs using same RefitRestService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,4 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,5 +9,9 @@ Install-Package Refit.Insane.PowerPack
 2. Read presentation I have created for Cracow #Xamarines - Xamarines.com
 https://github.com/thefex/Refit.Insane.PowerPack/blob/master/refit_presentation.pdf
 
+3. In order to use ApiDefinitionAttribute you need to either:
+* Attach attributes to each refit API interface
+* Attach attribute to only specific API interfaces but also set BaseApiConfiguration.ApiUri which will be used as base uri for all interfaces without ApiDefinition attribute
+
 # Acknowledgment
 This library has been created thanks to help and support from InsaneLab.com (http://www.insanelab.com). Thanks for giving me time to work on this project - you guys rock :-)

--- a/Refit.Insane.PowerPack/Attributes/ApiDefinitionAttribute.cs
+++ b/Refit.Insane.PowerPack/Attributes/ApiDefinitionAttribute.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Refit.Insane.PowerPack.Attributes
+{
+    public class ApiDefinitionAttribute : Attribute
+    {
+        public ApiDefinitionAttribute(string baseUri) : this()
+        {
+            BaseUri = baseUri;
+            HttpClientHandlerType = typeof(HttpClientDiagnosticsHandler);
+        }
+        
+        public ApiDefinitionAttribute(string baseUri, Type httpClientHandlerType) : this()
+        {
+            BaseUri = baseUri;
+            HttpClientHandlerType = httpClientHandlerType;
+        }
+
+        private ApiDefinitionAttribute()
+        {
+            ApiTimeout = TimeSpan.FromSeconds(5);
+        }
+
+        public TimeSpan ApiTimeout { get; }
+
+        public string BaseUri { get; }
+        
+        public Type HttpClientHandlerType { get; }
+    }
+}

--- a/Refit.Insane.PowerPack/Attributes/ApiDefinitionAttributeExtension.cs
+++ b/Refit.Insane.PowerPack/Attributes/ApiDefinitionAttributeExtension.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Refit.Insane.PowerPack.Configuration;
+
+namespace Refit.Insane.PowerPack.Attributes
+{
+    public static class ApiDefinitionAttributeExtension
+    {	
+        public static Uri GetUri<TApi>()
+        {
+            var attribute = GetAttribute<TApi>();
+            return attribute != null ? new Uri(attribute.BaseUri) : BaseApiConfiguration.ApiUri;
+        }
+        
+        public static TimeSpan GetTimeout<TApi>()
+        {
+            var attribute = GetAttribute<TApi>();
+            return attribute?.ApiTimeout ?? TimeSpan.FromSeconds(5);
+        }
+		
+        public static Type GetHttpClientHandlerType<TApi>()
+        {
+            var attribute = GetAttribute<TApi>();
+            return attribute != null ? attribute.HttpClientHandlerType : typeof(HttpClientDiagnosticsHandler);
+        }
+
+        private static ApiDefinitionAttribute GetAttribute<TApi>()
+        {
+            var attrs = typeof(TApi).GetTypeInfo().GetCustomAttributes(typeof(ApiDefinitionAttribute));
+            return attrs.FirstOrDefault(attr => attr is ApiDefinitionAttribute) as ApiDefinitionAttribute;
+        }
+    }
+}

--- a/Refit.Insane.PowerPack/Attributes/HttpClientDiagnosticsHandler.cs
+++ b/Refit.Insane.PowerPack/Attributes/HttpClientDiagnosticsHandler.cs
@@ -1,0 +1,46 @@
+﻿using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Refit.Insane.PowerPack.Attributes
+{
+    public class HttpClientDiagnosticsHandler : DelegatingHandler
+    {
+        public HttpClientDiagnosticsHandler(HttpMessageHandler innerHandler)
+            : base(innerHandler)
+        {
+        }
+
+        public HttpClientDiagnosticsHandler() : base(new HttpClientHandler())
+        {
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            HttpResponseMessage httpResponseMessage;
+            Stopwatch totalElapsedTime = Stopwatch.StartNew();
+            Debug.WriteLine($"Request: {request}");
+            if (request?.Content != null)
+            {
+                string str = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                Debug.WriteLine($"Request Content: {str}");
+            }
+            Stopwatch responseElapsedTime = Stopwatch.StartNew();
+            HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
+            Debug.WriteLine($"Response: {response}");
+            if (response?.Content != null)
+            {
+                string str = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                Debug.WriteLine($"Response Content: {str}");
+            }
+            responseElapsedTime.Stop();
+            Debug.WriteLine($"Response elapsed time: {responseElapsedTime.ElapsedMilliseconds} ms");
+            totalElapsedTime.Stop();
+            Debug.WriteLine($"Total elapsed time: {totalElapsedTime.ElapsedMilliseconds} ms");
+            httpResponseMessage = response;
+            return httpResponseMessage;
+        }
+    }
+}

--- a/Refit.Insane.PowerPack/Configuration/BaseApiConfiguration.cs
+++ b/Refit.Insane.PowerPack/Configuration/BaseApiConfiguration.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Refit.Insane.PowerPack.Configuration
+{
+    public static class BaseApiConfiguration
+    {
+        public static Uri ApiUri { get; set; }
+    }
+}

--- a/Refit.Insane.PowerPack/Refit.Insane.PowerPack.csproj
+++ b/Refit.Insane.PowerPack/Refit.Insane.PowerPack.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -28,6 +28,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Attributes\ApiDefinitionAttribute.cs" />
+    <Compile Include="Attributes\ApiDefinitionAttributeExtension.cs" />
+    <Compile Include="Attributes\HttpClientDiagnosticsHandler.cs" />
+    <Compile Include="Configuration\BaseApiConfiguration.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Data\Response.cs" />
     <Compile Include="Services\IRestService.cs" />

--- a/Refit.Insane.PowerPack/Services/RestServiceBuilder.cs
+++ b/Refit.Insane.PowerPack/Services/RestServiceBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Reflection;
 
@@ -20,10 +21,24 @@ namespace Refit.Insane.PowerPack.Services
             isCacheEnabled = shouldEnableCache;
             return this;
         }
-
-        public IRestService BuildRestService(Func<HttpClient> httpClientFactory, Assembly restApiAssembly) 
+        
+        public IRestService BuildRestService(Assembly restApiAssembly) 
         {
-            var refitRestService = new RefitRestService(httpClientFactory);
+            var refitRestService = new RefitRestService();
+
+            return BuildRestService(refitRestService, restApiAssembly);
+        }
+
+        public IRestService BuildRestService(IDictionary<Type, DelegatingHandler> handlerImplementations, Assembly restApiAssembly) 
+        {
+            var refitRestService = new RefitRestService(handlerImplementations);
+
+            return BuildRestService(refitRestService, restApiAssembly);
+        }
+        
+        public IRestService BuildRestService(IDictionary<Type, Func<DelegatingHandler>> handlerFactories, Assembly restApiAssembly) 
+        {
+            var refitRestService = new RefitRestService(handlerFactories);
 
             return BuildRestService(refitRestService, restApiAssembly);
         }

--- a/Sample/SampleApp.Core/App.cs
+++ b/Sample/SampleApp.Core/App.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Net.Http;
 using System.Reflection;
 using MvvmCross.Platform;
 using MvvmCross.Platform.IoC;
+using Refit.Insane.PowerPack.Configuration;
 using Refit.Insane.PowerPack.Services;
 using SampleApp.Core.ViewModels;
 
@@ -10,8 +10,6 @@ namespace SampleApp.Core
 {
     public class App : MvvmCross.Core.ViewModels.MvxApplication
     {
-        public static Uri ApiPath => new Uri("http://apitestprezentacja.azurewebsites.net/");
-
         public override void Initialize()
         {
             CreatableTypes()
@@ -22,17 +20,15 @@ namespace SampleApp.Core
             Mvx.RegisterType<MainViewModel>(() => new MainViewModel(Mvx.Resolve<IRestService>()));
             Mvx.RegisterType<ClientDetailsViewModel>(() => new ClientDetailsViewModel(Mvx.Resolve<IRestService>()));
 
+            BaseApiConfiguration.ApiUri = new Uri("http://apitestprezentacja.azurewebsites.net/");
+            
             Mvx.RegisterType<IRestService>(() =>
             {
                 var restServiceBuilder = new RestServiceBuilder()
                     .WithCaching()
                     .WithAutoRetry();
 
-                return restServiceBuilder.BuildRestService(() => new System.Net.Http.HttpClient(
-                    new HttpClientDiagnostics.HttpClientDiagnosticsHandler(new HttpClientHandler())){
-                    Timeout = TimeSpan.FromSeconds(5),
-                    BaseAddress = ApiPath
-                }, typeof(App).GetTypeInfo().Assembly);
+                return restServiceBuilder.BuildRestService(typeof(App).GetTypeInfo().Assembly);
             });
 
             RegisterAppStart<MainViewModel>();


### PR DESCRIPTION
### Problem to solve

Support many different APIs using same RefitRestService

### Changes

* Adds ApiDefinitionAttribute
* Based on ApiDefinitionAttribute creates and caches HttpClient implementations
* Refactors code to support changes

### Possible problems

* Not found

### Additional changes

* Adds .DS_Store file to .gitignore