### PR TITLE
Let ApiDefinitionAttribute be used to specify a custom HttpClientHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,5 @@ __pycache__/
 *.odx.cs
 *.xsd.cs
 .DS_Store
+
+Refit\.Insane\.PowerPack/\.mfractor/

--- a/Refit.Insane.PowerPack/Attributes/ApiDefinitionAttribute.cs
+++ b/Refit.Insane.PowerPack/Attributes/ApiDefinitionAttribute.cs
@@ -5,24 +5,29 @@ namespace Refit.Insane.PowerPack.Attributes
     public class ApiDefinitionAttribute : Attribute
     {
         private const int DefaultTimeoutInSeconds = 5;
-        
+
+        public ApiDefinitionAttribute(Type httpClientHandlerType) : this(DefaultTimeoutInSeconds)
+        {
+            HttpClientHandlerType = httpClientHandlerType;
+        }
+
         public ApiDefinitionAttribute(string baseUri) : this(DefaultTimeoutInSeconds)
         {
             BaseUri = baseUri;
             HttpClientHandlerType = typeof(HttpClientDiagnosticsHandler);
         }
-        
+
         public ApiDefinitionAttribute(string baseUri, int apiTimoutInSeconds) : this(apiTimoutInSeconds)
         {
             BaseUri = baseUri;
             HttpClientHandlerType = typeof(HttpClientDiagnosticsHandler);
         }
-        
+
         public ApiDefinitionAttribute(string baseUri, Type httpClientHandlerType) : this(baseUri)
         {
             HttpClientHandlerType = httpClientHandlerType;
         }
-        
+
         public ApiDefinitionAttribute(string baseUri, int apiTimeoutInSeconds, Type httpClientHandlerType) : this(baseUri, apiTimeoutInSeconds)
         {
             HttpClientHandlerType = httpClientHandlerType;
@@ -36,7 +41,7 @@ namespace Refit.Insane.PowerPack.Attributes
         public TimeSpan ApiTimeout { get; }
 
         public string BaseUri { get; }
-        
+
         public Type HttpClientHandlerType { get; }
     }
 }

--- a/Refit.Insane.PowerPack/Attributes/ApiDefinitionAttributeExtension.cs
+++ b/Refit.Insane.PowerPack/Attributes/ApiDefinitionAttributeExtension.cs
@@ -6,19 +6,23 @@ using Refit.Insane.PowerPack.Configuration;
 namespace Refit.Insane.PowerPack.Attributes
 {
     public static class ApiDefinitionAttributeExtension
-    {	
+    {
         public static Uri GetUri<TApi>()
         {
             var attribute = GetAttribute<TApi>();
-            return attribute != null ? new Uri(attribute.BaseUri) : BaseApiConfiguration.ApiUri;
+
+            // If the value of the URI seems to be empty, always fallback on the BaseApiConfiguration value
+            bool hasAttributeUri = attribute != null && !string.IsNullOrEmpty(attribute.BaseUri?.Trim());
+
+            return hasAttributeUri ? new Uri(attribute.BaseUri) : BaseApiConfiguration.ApiUri;
         }
-        
+
         public static TimeSpan GetTimeout<TApi>()
         {
             var attribute = GetAttribute<TApi>();
             return attribute?.ApiTimeout ?? BaseApiConfiguration.Timeout;
         }
-		
+
         public static Type GetHttpClientHandlerType<TApi>()
         {
             var attribute = GetAttribute<TApi>();


### PR DESCRIPTION
The goal of this PR is to allow more flexibility in using the ApiDefinitionAttribute in combinaison with the BaseApiConfiguration.

Since the nuget package is compiled in Release mode, the default HttpClientDiagnosticsHandler does not log anything. Right now, providing a custom HttpClientHandler requires to use the ApiDefinitionAttribute with a constant API URI value.

When using dynamics URI, we must use the Base BaseApiConfiguration.ApiUri property to fill in the BaseUri value, and in that scenario we loose the option of providing a custom HttpClientHandler.

The end goal of this PR, is to keep being able to provide a custom HttpClientHandler per API interfaces, while using a dynamic URI.